### PR TITLE
Add custom config validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,22 @@ class ServerlessPluginExistingCloudFrontLambdaEdge {
     this._alreadyWaitingForUpdates = new Set()
     this._distIdIsWaiting = null
 
+    // Create schema for your properties. For reference use https://github.com/ajv-validator/ajv
+    this.serverless.configSchemaHandler.defineFunctionProperties('aws', {
+      type: 'object',
+      properties: {
+        lambdaAtEdge: {
+          type: 'object',
+          properties: {
+            distributionID: { type: 'string' },
+            eventType: { type: 'string' }
+          },
+          required: ['distributionID', 'eventType'],
+          additionalProperties: false
+        }
+      }
+    })
+
     this.hooks = {
       'aws:package:finalize:mergeCustomProviderResources': this.onPackageCustomResources.bind(
         this

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -21,6 +21,9 @@ function stubServerless() {
       log: jest.fn(),
       consoleLog: jest.fn(),
       printDot: jest.fn()
+    },
+    configSchemaHandler: {
+      defineFunctionProperties: jest.fn()
     }
   }
 }
@@ -82,6 +85,25 @@ describe('serverless-plugin-existing-cloudfront-lambda-edge', function () {
     }
 
     stubbedSls = plugin.serverless
+  })
+
+  it('adds schema validation', () => {
+    expect(
+      stubbedSls.configSchemaHandler.defineFunctionProperties
+    ).toHaveBeenCalledWith('aws', {
+      type: 'object',
+      properties: {
+        lambdaAtEdge: {
+          type: 'object',
+          properties: {
+            distributionID: { type: 'string' },
+            eventType: { type: 'string' }
+          },
+          required: ['distributionID', 'eventType'],
+          additionalProperties: false
+        }
+      }
+    })
   })
 
   it('throws error if provider aws does not exist', () => {


### PR DESCRIPTION
- Fixes the warning of `lambdaAtEdge` as an invalid function property
- Validates `distributionID` and `eventType` are set and are strings